### PR TITLE
Docker化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# JDK 21の公式イメージをベースとする
+FROM openjdk:21-slim-bullseye AS build
+
+# 必要なツールをインストール
+RUN apt-get update && apt-get install -y findutils
+
+# 作業ディレクトリを設定
+WORKDIR /app
+
+# ホストのソースコードをDockerイメージ内にコピー
+COPY . .
+
+# Gradleを使ってビルドを実行
+RUN ./gradlew build --no-daemon
+
+# アプリケーションの実行コマンドを指定
+ENTRYPOINT ["java", "-jar", "/app/build/libs/my-spring-0.0.1-SNAPSHOT.jar"]

--- a/api.oas3.yml
+++ b/api.oas3.yml
@@ -1,0 +1,44 @@
+openapi: 3.0.2
+info:
+  title: Pet API
+  version: 1.0.0
+paths:
+  /pet:
+    get:
+      summary: Retrieve a pet
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                '$ref': '#/components/schemas/Pet'
+              examples:
+                cat:
+                  summary: An example of a cat
+                  value:
+                    id: 2
+                    name: Fluffy
+                    photoUrls: []
+                dog:
+                  summary: An example of a dog
+                  value:
+                    id: 1
+                    name: Spot
+                    photoUrls:
+                      - https://images.dog.ceo/breeds/kelpie/n02105412_893.jpg
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+          example: doggie
+        photoUrls:
+          type: array
+          items:
+            type: string

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.9'
+services:
+  prism:
+    image: stoplight/prism:4
+    command: 'mock -h 0.0.0.0 /tmp/api.oas3.yml'
+    volumes:
+      - ./api.oas3.yml:/tmp/api.oas3.yml:ro
+    ports:
+      # Serve the mocked API locally as available on port 8080
+      - '4010:4010'
+  my-spring:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    volumes:
+      - "./gradle:/home/gradle/.gradle"


### PR DESCRIPTION
mockもついでに追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Chores:
- Updated the base Docker image to `openjdk:21-slim-bullseye`, ensuring compatibility with JDK 21.
- Installed `findutils` package, enhancing file search capabilities within the Docker image.
- Set the working directory to `/app` and copied the current directory into the Docker image, streamlining the Docker setup process.
- Executed the Gradle build command using `./gradlew build --no-daemon`, improving build efficiency.
- Set the entrypoint command to `java -jar /app/build/libs/my-spring-0.0.1-SNAPSHOT.jar`, enabling the application to run immediately upon Docker container startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->